### PR TITLE
Fix a typo.

### DIFF
--- a/R/compile.R
+++ b/R/compile.R
@@ -378,7 +378,7 @@ function(e, env, ir, ..., fun = env$.fun, name = getName(fun), .targetType = NUL
       return(e)
     
     if (is.call(e)) {
-      disptchCompilerHandlers(e, env$.compilerHandlers, env, ir, ...)
+      dispatchCompilerHandlers(e, env$.compilerHandlers, env, ir, ...)
     } else if (is.symbol(e)) {
       var <- as.character(e)
       return(var) ## TODO: lookup here, or in OP function?


### PR DESCRIPTION
This fixes a typo in `compile.default()`.
